### PR TITLE
Story5: prioritising keywords

### DIFF
--- a/src/main/java/nz/ac/auckland/Keyword.java
+++ b/src/main/java/nz/ac/auckland/Keyword.java
@@ -14,6 +14,6 @@ public class Keyword {
     }
 
 	public int getWeight() {
-		return -1;
+		return 4;
 	}
 }

--- a/src/main/java/nz/ac/auckland/Keyword.java
+++ b/src/main/java/nz/ac/auckland/Keyword.java
@@ -12,4 +12,8 @@ public class Keyword {
     public void setWeight(int weight){
         this.weight = weight;
     }
+
+	public int getWeight() {
+		return -1;
+	}
 }

--- a/src/main/java/nz/ac/auckland/Keyword.java
+++ b/src/main/java/nz/ac/auckland/Keyword.java
@@ -7,6 +7,7 @@ public class Keyword {
 
     public Keyword(String word){
         this.word = word;
+        this.weight = 1;
     }
 
     public void setWeight(int weight){

--- a/src/main/java/nz/ac/auckland/Keyword.java
+++ b/src/main/java/nz/ac/auckland/Keyword.java
@@ -14,6 +14,6 @@ public class Keyword {
     }
 
 	public int getWeight() {
-		return 4;
+		return this.weight;
 	}
 }

--- a/src/main/java/nz/ac/auckland/KeywordService.java
+++ b/src/main/java/nz/ac/auckland/KeywordService.java
@@ -72,7 +72,7 @@ public class KeywordService {
 	}
 
 	public void updateWeight(String word, int newWeight) {
-		if (newWeight == 0) return;
+		if (newWeight <= 0 || newWeight > 10) return;
 		
 		for (int i = 0; i < this._keywords.size(); i++) {
 			Keyword keyword = this._keywords.get(i);

--- a/src/main/java/nz/ac/auckland/KeywordService.java
+++ b/src/main/java/nz/ac/auckland/KeywordService.java
@@ -71,4 +71,8 @@ public class KeywordService {
 		_keywords.add(keyword);
 	}
 
+	public void updateWeight(String word, int newWeight) {
+		
+	}
+
 }

--- a/src/main/java/nz/ac/auckland/KeywordService.java
+++ b/src/main/java/nz/ac/auckland/KeywordService.java
@@ -72,6 +72,8 @@ public class KeywordService {
 	}
 
 	public void updateWeight(String word, int newWeight) {
+		if (newWeight == 0) return;
+		
 		for (int i = 0; i < this._keywords.size(); i++) {
 			Keyword keyword = this._keywords.get(i);
 			if (keyword.word.equals(word)) {

--- a/src/main/java/nz/ac/auckland/KeywordService.java
+++ b/src/main/java/nz/ac/auckland/KeywordService.java
@@ -72,7 +72,12 @@ public class KeywordService {
 	}
 
 	public void updateWeight(String word, int newWeight) {
-		
+		for (int i = 0; i < this._keywords.size(); i++) {
+			Keyword keyword = this._keywords.get(i);
+			if (keyword.word.equals(word)) {
+				keyword.setWeight(newWeight);
+			}
+		}
 	}
 
 }

--- a/src/test/java/nz/ac/auckland/acceptance/KeywordExtractionStepDefs.java
+++ b/src/test/java/nz/ac/auckland/acceptance/KeywordExtractionStepDefs.java
@@ -29,13 +29,15 @@ public class KeywordExtractionStepDefs {
 		this._keywordService.updateWeight(word, newWeight);
 	}
 
-	@Then("^the weight of keyword \"(.*)\" is updated to (\\d+)$")
-	public void the_weight_of_keyword_is_updated_to(String word, int newWeight) throws Exception {
+	@Then("^the weight of keyword \"(.*)\" (is|is not) updated to (\\d+)$")
+	public void the_weight_of_keyword_is_updated_to(String word, String updated, int newWeight) throws Exception {
+		boolean weightShouldBeUpdated = updated.equals("is");
+		
 		List<Keyword> extractedKeywords = this._keywordService.getKeywords();
 		for (int i = 0; i < extractedKeywords.size(); i++) {
 			Keyword keyword = extractedKeywords.get(i);
 			if (keyword.word.equals(word)) {
-				assertEquals(keyword.getWeight(), newWeight);
+				assertEquals(keyword.getWeight() == newWeight, weightShouldBeUpdated);
 			}
 		}
 	}

--- a/src/test/java/nz/ac/auckland/acceptance/KeywordExtractionStepDefs.java
+++ b/src/test/java/nz/ac/auckland/acceptance/KeywordExtractionStepDefs.java
@@ -1,0 +1,43 @@
+package nz.ac.auckland.acceptance;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KeywordExtractionStepDefs {
+
+	private KeywordService _keywordService;
+
+	@Given("^a User already has a number of keywords returned$")
+	public void a_User_already_has_a_number_of_keywords_returned() throws Exception {
+		List<Keyword> extractedKeywords = new ArrayList<Keyword>();
+		extractedKeywords.add(new Keyword("Dog"));
+		extractedKeywords.add(new Keyword("Walking"));
+		extractedKeywords.add(new Keyword("Ponsonby"));
+
+		KeywordExtractor _keywordExtractor = mock(KeywordExtractor.class);
+		when(_keywordExtractor.extractFrom("A dog walking service in Ponsonby")).thenReturn(extractedKeywords);
+		this._keywordService = new KeywordService(_keywordExtractor);
+
+		this._keywordService.extractFrom("A dog walking service in Ponsonby");
+	}
+
+	@When("^the User requests to change the weight of keyword \"(.*)\" to (\\d+)$")
+	public void the_User_requests_to_change_the_weight_of_keyword_to(String word, int newWeight) throws Exception {
+		this._keywordService.updateWeight(word, newWeight);
+	}
+
+	@Then("^the weight of keyword \"(.*)\" is updated to (\\d+)$")
+	public void the_weight_of_keyword_is_updated_to(String word, int newWeight) throws Exception {
+		List<Keyword> extractedKeywords = this._keywordService.getKeywords();
+		for (int i = 0; i < extractedKeywords.size(); i++) {
+			Keyword keyword = extractedKeywords.get(i);
+			if (keyword.word.equals(word)) {
+				assertEquals(keyword.getWeight(), newWeight);
+			}
+		}
+	}
+}

--- a/src/test/java/nz/ac/auckland/acceptance/KeywordExtractionStepDefs.java
+++ b/src/test/java/nz/ac/auckland/acceptance/KeywordExtractionStepDefs.java
@@ -20,15 +20,7 @@ public class KeywordExtractionStepDefs {
 
 	@Given("^a User already has a number of keywords returned$")
 	public void a_User_already_has_a_number_of_keywords_returned() throws Exception {
-		List<Keyword> extractedKeywords = new ArrayList<Keyword>();
-		extractedKeywords.add(new Keyword("dog"));
-		extractedKeywords.add(new Keyword("walking"));
-		extractedKeywords.add(new Keyword("Ponsonby"));
-
-		KeywordExtractor _keywordExtractor = mock(KeywordExtractor.class);
-		when(_keywordExtractor.extractFrom("A dog walking service in Ponsonby")).thenReturn(extractedKeywords);
-		this._keywordService = new KeywordService(_keywordExtractor);
-
+		initializeKeywordServiceWithMockKeywordExtractor();
 		this._keywordService.extractFrom("A dog walking service in Ponsonby");
 	}
 
@@ -46,5 +38,16 @@ public class KeywordExtractionStepDefs {
 				assertEquals(keyword.getWeight(), newWeight);
 			}
 		}
+	}
+	
+	private void initializeKeywordServiceWithMockKeywordExtractor() {
+		List<Keyword> extractedKeywords = new ArrayList<Keyword>();
+		extractedKeywords.add(new Keyword("dog"));
+		extractedKeywords.add(new Keyword("walking"));
+		extractedKeywords.add(new Keyword("Ponsonby"));
+
+		KeywordExtractor _keywordExtractor = mock(KeywordExtractor.class);
+		when(_keywordExtractor.extractFrom("A dog walking service in Ponsonby")).thenReturn(extractedKeywords);
+		this._keywordService = new KeywordService(_keywordExtractor);
 	}
 }

--- a/src/test/java/nz/ac/auckland/acceptance/KeywordExtractionStepDefs.java
+++ b/src/test/java/nz/ac/auckland/acceptance/KeywordExtractionStepDefs.java
@@ -3,9 +3,16 @@ package nz.ac.auckland.acceptance;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
+import nz.ac.auckland.Keyword;
+import nz.ac.auckland.KeywordExtractor;
+import nz.ac.auckland.KeywordService;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class KeywordExtractionStepDefs {
 
@@ -14,8 +21,8 @@ public class KeywordExtractionStepDefs {
 	@Given("^a User already has a number of keywords returned$")
 	public void a_User_already_has_a_number_of_keywords_returned() throws Exception {
 		List<Keyword> extractedKeywords = new ArrayList<Keyword>();
-		extractedKeywords.add(new Keyword("Dog"));
-		extractedKeywords.add(new Keyword("Walking"));
+		extractedKeywords.add(new Keyword("dog"));
+		extractedKeywords.add(new Keyword("walking"));
 		extractedKeywords.add(new Keyword("Ponsonby"));
 
 		KeywordExtractor _keywordExtractor = mock(KeywordExtractor.class);

--- a/src/test/resources/nz/ac/auckland/acceptance/TestPrioritisingKeywords.feature
+++ b/src/test/resources/nz/ac/auckland/acceptance/TestPrioritisingKeywords.feature
@@ -5,3 +5,8 @@ Feature: Business Idea Keyword Extraction
 				Given a User already has a number of keywords returned
 				When the User requests to change the weight of keyword "dog" to 4
 				Then the weight of keyword "dog" is updated to 4
+
+		Scenario: A User changes the weight of a specified keyword to an invalid weight
+				Given a User already has a number of keywords returned
+				When the User requests to change the weight of keyword "walking" to 0
+				Then the weight of keyword "walking" is not updated to 0

--- a/src/test/resources/nz/ac/auckland/acceptance/TestPrioritisingKeywords.feature
+++ b/src/test/resources/nz/ac/auckland/acceptance/TestPrioritisingKeywords.feature
@@ -1,0 +1,7 @@
+Feature: Business Idea Keyword Extraction
+		Users can prioritise the keywords by changing the weights of the keywords.
+
+		Scenario: A User changes the weight of a specified keyword to an acceptable weight
+				Given a User already has a number of keywords returned
+				When the User requests to change the weight of keyword "dog" to 4
+				Then the weight of keyword "dog" is updated to 4


### PR DESCRIPTION
Test Cases Covered:

1. User successfully changes weight of a keyword
2. User enters invalid weight (should be between 0 and 10), keyword weight not updated